### PR TITLE
Deprecate LightningModule.summarize() in favor of pytorch_lightning.utilities.model_summary.summarize()

### DIFF
--- a/.azure-pipelines/gpu_benchmark.yml
+++ b/.azure-pipelines/gpu_benchmark.yml
@@ -1,0 +1,27 @@
+name: GPU Parity testing
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # At the end of every day
+
+jobs:
+  parity-test:
+    timeoutInMinutes: 120
+
+    cancelTimeoutInMinutes: 2
+
+    pool: gridai-spot-pool
+
+    container:
+      # base ML image: mcr.microsoft.com/azureml/openmpi3.1.2-cuda10.2-cudnn8-ubuntu18.04
+      image: "pytorchlightning/pytorch_lightning:base-cuda-py3.8-torch1.6"
+
+    workspace:
+      clean: all
+
+    steps:
+      - bash: |
+          python -m pytest benchmarks -v --durations=0
+        displayName: 'Testing: benchmarks'
+        env:
+          PL_RUNNING_BENCHMARKS: 1

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,14 +16,14 @@ Fixes #<issue_number>
 <!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->
 
 ## Before submitting
-- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
+- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
 - [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
-- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
-- [ ] Did you make sure to update the documentation with your changes? (if necessary)
-- [ ] Did you write any new necessary tests? (not for typos and docs)
-- [ ] Did you verify new and existing tests pass locally with your changes?
-- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)
-- [ ] Did you list all the breaking changes introduced by this pull request?
+- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
+- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
+- [ ] Did you write any **new necessary tests**? (not for typos and docs)
+- [ ] Did you verify new and **existing tests pass** locally with your changes?
+- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)
+- [ ] Did you list all the **breaking changes** introduced by this pull request?
 
 <!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - MLflowLogger now uses the env variable `MLFLOW_TRACKING_URI` as default tracking uri ([#7457](https://github.com/PyTorchLightning/pytorch-lightning/pull/7457))
 
+
 - Changed `Trainer` arg and functionality from `reload_dataloaders_every_epoch` to `reload_dataloaders_every_n_epochs` ([#5043](https://github.com/PyTorchLightning/pytorch-lightning/pull/5043))
+
 
 - Changed `WandbLogger(log_model={True/'all'})` to log models as artifacts ([#6231](https://github.com/PyTorchLightning/pytorch-lightning/pull/6231))
 
@@ -324,6 +326,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Added private `prevent_trainer_and_dataloaders_deepcopy` context manager on the `LightningModule` ([#8472](https://github.com/PyTorchLightning/pytorch-lightning/pull/8472))
+
+
+- Moved `DeviceDtypeModuleMixin` and `HyperparametersMixin` mixin to `core` ([#8396](https://github.com/PyTorchLightning/pytorch-lightning/pull/8396))
+
+
+- Return the `default_root_dir` as the `log_dir` when the logger is a `LoggerCollection` ([#8187](https://github.com/PyTorchLightning/pytorch-lightning/pull/8187))
 
 
 ### Deprecated
@@ -423,6 +431,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed the `GPUStatsMonitor` callbacks to use the correct GPU IDs if `CUDA_VISIBLE_DEVICES` set ([#8260](https://github.com/PyTorchLightning/pytorch-lightning/pull/8260))
 
+
 - Fixed `lr_scheduler` checkpointed state by calling `update_lr_schedulers` before saving checkpoints ([#7877](https://github.com/PyTorchLightning/pytorch-lightning/pull/7877))
 
 
@@ -484,6 +493,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Fixed missing call to `LightningModule.untoggle_optimizer` in training loop when running gradient accumulation with multiple optimizers ([#8284](https://github.com/PyTorchLightning/pytorch-lightning/pull/8284))
+
+
+- Fixed hash of LightningEnum to work with value instead of name ([#8421](https://github.com/PyTorchLightning/pytorch-lightning/pull/8421)).
+
+
+- Fixed a bug where an extra checkpoint was saved at the end of training if the `val_check_interval` did not align with the number of training batches ([#7724](https://github.com/PyTorchLightning/pytorch-lightning/pull/7724))
 
 
 - Fixed hash of LightningEnum to work with value instead of name([#8421](https://github.com/PyTorchLightning/pytorch-lightning/pull/8421)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -485,7 +485,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed missing call to `LightningModule.untoggle_optimizer` in training loop when running gradient accumulation with multiple optimizers ([#8284](https://github.com/PyTorchLightning/pytorch-lightning/pull/8284))
 
+
 - Fixed hash of LightningEnum to work with value instead of name([#8421](https://github.com/PyTorchLightning/pytorch-lightning/pull/8421)).
+
 
 - Fixed `move_data_to_device` to return the batch if the object `to` function didn't return `self` ([#8433](https://github.com/PyTorchLightning/pytorch-lightning/pull/8433))
 
@@ -494,6 +496,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Fixed clearing dataloader references before attaching new dataloaders in consecutive `Trainer.{fit,validate,test,predict}´ runs ([#8442](https://github.com/PyTorchLightning/pytorch-lightning/pull/8442))
+
+
+- Fixed memory leaks on GPU by moving `optimizer_states`, `ResultCollection.extra`, `ResultMetric` attributes, and `LoggerConnector` metrics to `cpu`. Also, delete the DDP wrapper on `teardown` ([#8490](https://github.com/PyTorchLightning/pytorch-lightning/pull/8490))
 
 
 - Fixed `SWA` callback using LightningModule `prevent_trainer_and_dataloaders_deepcopy` to avoid OOM ([#8472](https://github.com/PyTorchLightning/pytorch-lightning/pull/8472))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,7 +510,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed DeepSpeed Windows support ([#8488](https://github.com/PyTorchLightning/pytorch-lightning/pull/8488))
 
 
+- Fixed `accumulate_grad_batches` not been recomputed during model reload ([#5334](https://github.com/PyTorchLightning/pytorch-lightning/pull/5334))
+
+
 - Fixed a `TypeError` when wrapping optimizers in the `HorovodPlugin` and running `Trainer.test` ([#7840](https://github.com/PyTorchLightning/pytorch-lightning/pull/7840))
+
 
 
 ## [1.3.8] - 2021-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -505,6 +505,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed DeepSpeed Windows support ([#8488](https://github.com/PyTorchLightning/pytorch-lightning/pull/8488))
 
 
+- Fixed a `TypeError` when wrapping optimizers in the `HorovodPlugin` and running `Trainer.test` ([#7840](https://github.com/PyTorchLightning/pytorch-lightning/pull/7840))
+
+
 ## [1.3.8] - 2021-07-01
 
 ### Fixed

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 import os
 
-BENCHMARK_ROOT = os.path.dirname(__file__)
-PROJECT_ROOT = os.path.dirname(BENCHMARK_ROOT)
+_BENCHMARK_ROOT = os.path.dirname(__file__)
+_PROJECT_ROOT = os.path.dirname(_BENCHMARK_ROOT)
+_PATH_DATASETS = os.path.join(_PROJECT_ROOT, 'Datasets')

--- a/pl_examples/basic_examples/profiler_example.py
+++ b/pl_examples/basic_examples/profiler_example.py
@@ -29,7 +29,7 @@ import torchvision
 import torchvision.models as models
 import torchvision.transforms as T
 
-from pl_examples import cli_lightning_logo
+from pl_examples import _DATASETS_PATH, cli_lightning_logo
 from pytorch_lightning import LightningDataModule, LightningModule
 from pytorch_lightning.utilities.cli import LightningCLI
 
@@ -75,11 +75,13 @@ class CIFAR10DataModule(LightningDataModule):
     transform = T.Compose([T.Resize(256), T.CenterCrop(224), T.ToTensor()])
 
     def train_dataloader(self, *args, **kwargs):
-        trainset = torchvision.datasets.CIFAR10(root='./data', train=True, download=True, transform=self.transform)
+        trainset = torchvision.datasets.CIFAR10(
+            root=_DATASETS_PATH, train=True, download=True, transform=self.transform
+        )
         return torch.utils.data.DataLoader(trainset, batch_size=32, shuffle=True, num_workers=0)
 
     def val_dataloader(self, *args, **kwargs):
-        valset = torchvision.datasets.CIFAR10(root='./data', train=False, download=True, transform=self.transform)
+        valset = torchvision.datasets.CIFAR10(root=_DATASETS_PATH, train=False, download=True, transform=self.transform)
         return torch.utils.data.DataLoader(valset, batch_size=32, shuffle=True, num_workers=0)
 
 

--- a/pytorch_lightning/__about__.py
+++ b/pytorch_lightning/__about__.py
@@ -1,7 +1,7 @@
 import time
 
 _this_year = time.strftime("%Y")
-__version__ = '1.4.0rc0'
+__version__ = '1.4.0rc1'
 __author__ = 'William Falcon et al.'
 __author_email__ = 'waf2107@columbia.edu'
 __license__ = 'Apache-2.0'

--- a/pytorch_lightning/accelerators/gpu.py
+++ b/pytorch_lightning/accelerators/gpu.py
@@ -52,3 +52,7 @@ class GPUAccelerator(Accelerator):
         all_gpu_ids = ",".join([str(x) for x in range(torch.cuda.device_count())])
         devices = os.getenv("CUDA_VISIBLE_DEVICES", all_gpu_ids)
         _log.info(f"LOCAL_RANK: {local_rank} - CUDA_VISIBLE_DEVICES: [{devices}]")
+
+    def teardown(self) -> None:
+        super().teardown()
+        self._move_optimizer_state(torch.device("cpu"))

--- a/pytorch_lightning/accelerators/tpu.py
+++ b/pytorch_lightning/accelerators/tpu.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
+import torch
 from torch.optim import Optimizer
 
 import pytorch_lightning as pl
@@ -21,6 +22,7 @@ from pytorch_lightning.plugins.precision import MixedPrecisionPlugin
 from pytorch_lightning.plugins.training_type.single_tpu import SingleTPUPlugin
 from pytorch_lightning.plugins.training_type.tpu_spawn import TPUSpawnPlugin
 from pytorch_lightning.utilities import _XLA_AVAILABLE
+from pytorch_lightning.utilities.apply_func import apply_to_collection, move_data_to_device
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 if _XLA_AVAILABLE:
@@ -49,3 +51,11 @@ class TPUAccelerator(Accelerator):
         self, optimizer: Optimizer, optimizer_idx: int, lambda_closure: Callable, **kwargs: Any
     ) -> None:
         xm.optimizer_step(optimizer, optimizer_args={'closure': lambda_closure, **kwargs})
+
+    def _move_optimizer_state(self, device: Optional[torch.device] = None) -> None:
+        """ Moves the state of the optimizers to the TPU if needed. """
+        # TODO: `self.root_device` would raise error if called outside the spawn process
+        # while training on 8 and more cores.
+        for opt in self.optimizers:
+            for p, v in opt.state.items():
+                opt.state[p] = apply_to_collection(v, torch.Tensor, move_data_to_device, self.root_device)

--- a/pytorch_lightning/callbacks/gradient_accumulation_scheduler.py
+++ b/pytorch_lightning/callbacks/gradient_accumulation_scheduler.py
@@ -74,9 +74,13 @@ class GradientAccumulationScheduler(Callback):
     def going_to_accumulate_grad_batches(self):
         return any(v > 1 for v in self.scheduling.values())
 
-    def on_train_epoch_start(self, trainer, pl_module):
-        epoch = trainer.current_epoch
-        for i in reversed(range(len(self.epochs))):
-            if epoch >= self.epochs[i]:
-                trainer.accumulate_grad_batches = self.scheduling.get(self.epochs[i])
+    def get_accumulate_grad_batches(self, epoch: int) -> int:
+        accumulate_grad_batches = 1
+        for iter_epoch in reversed(self.epochs):
+            if epoch >= iter_epoch:
+                accumulate_grad_batches = self.scheduling.get(iter_epoch)
                 break
+        return accumulate_grad_batches
+
+    def on_train_epoch_start(self, trainer, *_):
+        trainer.accumulate_grad_batches = self.get_accumulate_grad_batches(trainer.current_epoch)

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -429,7 +429,7 @@ class LoggerCollection(LightningLoggerBase):
 class DummyExperiment(object):
     """ Dummy experiment """
 
-    def nop(*args, **kw):
+    def nop(self, *args, **kw):
         pass
 
     def __getattr__(self, _):

--- a/pytorch_lightning/plugins/training_type/parallel.py
+++ b/pytorch_lightning/plugins/training_type/parallel.py
@@ -133,6 +133,11 @@ class ParallelPlugin(TrainingTypePlugin, ABC):
             yield None
 
     def teardown(self) -> None:
+        # Un-reference the wrapper if any was used.
+        # todo (tchaton): Add support for all plugins.
+        if isinstance(self.model, DistributedDataParallel):
+            self.model = self.lightning_module
+
         if self.on_gpu:
             # GPU teardown
             self.lightning_module.cpu()

--- a/pytorch_lightning/plugins/training_type/training_type_plugin.py
+++ b/pytorch_lightning/plugins/training_type/training_type_plugin.py
@@ -39,7 +39,7 @@ class TrainingTypePlugin(Plugin, ABC):
     """
 
     def __init__(self) -> None:
-        self._model = None
+        self._model: Optional[Module] = None
         self._results: Optional[Union[_EVALUATE_OUTPUT, _PREDICT_OUTPUT]] = None
         self._call_configure_sharded_model_hook = True
 
@@ -121,12 +121,12 @@ class TrainingTypePlugin(Plugin, ABC):
         """Hook to do something after each optimizer step."""
 
     @property
-    def model(self) -> Module:
+    def model(self) -> Optional[Module]:
         """Returns the potentially wrapped LightningModule"""
         return self._model
 
     @model.setter
-    def model(self, new_model: Module) -> None:
+    def model(self, new_model: Optional[Module]) -> None:
         self._model = new_model
 
     @property

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -200,6 +200,9 @@ class CheckpointConnector:
 
         # Division deals with global step stepping once per accumulated batch
         # Inequality deals with different global step for odd vs even num_training_batches
+        self.trainer.accumulate_grad_batches = self.trainer.accumulation_scheduler.get_accumulate_grad_batches(
+            self.trainer.current_epoch
+        )
         n_accum = 1 if self.trainer.accumulate_grad_batches is None else self.trainer.accumulate_grad_batches
         expected_steps = self.trainer.num_training_batches / n_accum
         if self.trainer.num_training_batches != 0 and self.trainer.global_step % expected_steps > 1:

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -23,6 +23,7 @@ from pytorch_lightning.loggers import LightningLoggerBase, LoggerCollection, Ten
 from pytorch_lightning.trainer.connectors.logger_connector.result import _METRIC, MetricSource
 from pytorch_lightning.trainer.states import RunningStage, TrainerFn
 from pytorch_lightning.utilities import DeviceType
+from pytorch_lightning.utilities.apply_func import apply_to_collection, move_data_to_device
 from pytorch_lightning.utilities.metrics import metrics_to_scalars
 from pytorch_lightning.utilities.types import _EVALUATE_OUTPUT
 
@@ -312,3 +313,9 @@ class LoggerConnector:
             metrics = self.metrics[MetricSource.PBAR]
             self._progress_bar_metrics.update(metrics)
         return self._progress_bar_metrics
+
+    def teardown(self):
+        args = (torch.Tensor, move_data_to_device, "cpu")
+        self._logged_metrics = apply_to_collection(self._logged_metrics, *args)
+        self._progress_bar_metrics = apply_to_collection(self._progress_bar_metrics, *args)
+        self._callback_metrics = apply_to_collection(self._callback_metrics, *args)

--- a/pytorch_lightning/trainer/connectors/logger_connector/result.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result.py
@@ -21,9 +21,8 @@ from torchmetrics import Metric
 
 from pytorch_lightning.core.mixins import DeviceDtypeModuleMixin
 from pytorch_lightning.utilities import rank_zero_warn
-from pytorch_lightning.utilities.apply_func import apply_to_collection, apply_to_collections
+from pytorch_lightning.utilities.apply_func import apply_to_collection, apply_to_collections, move_data_to_device
 from pytorch_lightning.utilities.data import extract_batch_size
-from pytorch_lightning.utilities.distributed import distributed_available
 from pytorch_lightning.utilities.enums import LightningEnum
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.metrics import metrics_to_scalars
@@ -254,12 +253,7 @@ class ResultMetric(Metric, DeviceDtypeModuleMixin):
         if not self.is_tensor and drop_value:
             # Avoid serializing ResultMetrics which are passed Metrics
             skip.append('value')
-        with self.sync_context(
-            should_sync=not self.meta.sync.rank_zero_only,
-            process_group=self.meta.sync.group,
-            distributed_available=distributed_available
-        ):
-            d = {k: v for k, v in self.__dict__.items() if k not in skip}
+        d = {k: v for k, v in self.__dict__.items() if k not in skip}
         d['meta'] = d['meta'].__getstate__()
         d['_class'] = self.__class__.__name__
         return d
@@ -275,6 +269,12 @@ class ResultMetric(Metric, DeviceDtypeModuleMixin):
         result_metric = cls(meta, state['is_tensor'])
         result_metric.__setstate__(state, sync_fn=sync_fn)
         return result_metric
+
+    def to(self, *args: Any, **kwargs: Any) -> 'DeviceDtypeModuleMixin':
+        self.__dict__.update(
+            apply_to_collection(self.__dict__, (torch.Tensor, Metric), move_data_to_device, *args, **kwargs)
+        )
+        return self
 
 
 class ResultMetricCollection(dict):
@@ -597,10 +597,7 @@ class ResultCollection(dict):
     def to(self, *args, **kwargs) -> 'ResultCollection':
         """Move all data to the given device."""
 
-        def to_(item: Union[torch.Tensor, Metric], *args: Any, **kwargs: Any) -> Union[torch.Tensor, Metric]:
-            return item.to(*args, **kwargs)
-
-        apply_to_collection(self, (torch.Tensor, Metric), to_, *args, **kwargs)
+        self.update(apply_to_collection(dict(self), (torch.Tensor, Metric), move_data_to_device, *args, **kwargs))
 
         if self.minimize is not None:
             self.minimize = self.minimize.to(*args, **kwargs)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -964,6 +964,7 @@ class Trainer(
         # which need to happen before.
         self.accelerator.teardown()
         self._active_loop.teardown()
+        self.logger_connector.teardown()
 
     def _dispatch(self):
         if self.evaluating:

--- a/pytorch_lightning/utilities/device_dtype_mixin.py
+++ b/pytorch_lightning/utilities/device_dtype_mixin.py
@@ -1,0 +1,11 @@
+from pytorch_lightning.utilities import rank_zero_deprecation
+
+rank_zero_deprecation(
+    "`pytorch_lightning.utilities.device_dtype_mixin` has been moved to"
+    " `pytorch_lightning.core.mixins.device_dtype_mixin` since v1.4"
+    " and will be removed in v1.6."
+)
+
+# To support backward compatibility as `device_dtype_mixin` has been
+# moved to `pytorch_lightning.core.mixins.device_dtype_mixin`
+from pytorch_lightning.core.mixins.device_dtype_mixin import DeviceDtypeModuleMixin  # noqa: E402 F401 # isort: skip

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,8 +19,8 @@ import numpy as np
 _TEST_ROOT = os.path.dirname(__file__)
 _PROJECT_ROOT = os.path.dirname(_TEST_ROOT)
 _TEMP_PATH = os.path.join(_PROJECT_ROOT, 'test_temp')
-PATH_DATASETS = os.path.join(_PROJECT_ROOT, 'Datasets')
-PATH_LEGACY = os.path.join(_PROJECT_ROOT, 'legacy')
+_PATH_DATASETS = os.path.join(_PROJECT_ROOT, 'Datasets')
+_PATH_LEGACY = os.path.join(_PROJECT_ROOT, 'legacy')
 
 # todo: this setting `PYTHONPATH` may not be used by other evns like Conda for import packages
 if _PROJECT_ROOT not in os.getenv('PYTHONPATH', ""):

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -18,7 +18,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from pytorch_lightning.core.lightning import LightningModule
-from tests import PATH_DATASETS
+from tests import _PATH_DATASETS
 from tests.base.model_optimizers import ConfigureOptimizersPool
 from tests.base.model_test_dataloaders import TestDataloaderVariations
 from tests.base.model_test_epoch_ends import TestEpochEndVariations
@@ -59,7 +59,7 @@ class EvalModelTemplate(
         in_features: int = 28 * 28,
         learning_rate: float = 0.001 * 8,
         optimizer_name: str = 'adam',
-        data_root: str = PATH_DATASETS,
+        data_root: str = _PATH_DATASETS,
         out_features: int = 10,
         hidden_dim: int = 1000,
         b1: float = 0.5,
@@ -131,7 +131,7 @@ class EvalModelTemplate(
             in_features=28 * 28,
             learning_rate=0.001 * 8,
             optimizer_name='adam',
-            data_root=PATH_DATASETS,
+            data_root=_PATH_DATASETS,
             out_features=10,
             hidden_dim=1000,
             b1=0.5,

--- a/tests/checkpointing/test_legacy_checkpoints.py
+++ b/tests/checkpointing/test_legacy_checkpoints.py
@@ -18,9 +18,9 @@ import sys
 import pytest
 
 from pytorch_lightning import Trainer
-from tests import PATH_LEGACY
+from tests import _PATH_LEGACY
 
-LEGACY_CHECKPOINTS_PATH = os.path.join(PATH_LEGACY, 'checkpoints')
+LEGACY_CHECKPOINTS_PATH = os.path.join(_PATH_LEGACY, 'checkpoints')
 CHECKPOINT_EXTENSION = ".ckpt"
 
 

--- a/tests/checkpointing/test_trainer_checkpoint.py
+++ b/tests/checkpointing/test_trainer_checkpoint.py
@@ -84,3 +84,22 @@ def test_finetuning_with_resume_from_checkpoint(tmpdir):
             assert best_model_path.endswith(f"epoch=0{idx}.ckpt")
         else:
             assert f"epoch={idx + 1}" in best_model_path
+
+
+def test_accumulated_gradient_batches_with_resume_from_checkpoint(tmpdir):
+    """
+    This test validates that accumulated gradient is properly recomputed and reset on the trainer.
+    """
+
+    cb = ModelCheckpoint(dirpath=tmpdir, save_last=True)
+    model = BoringModel()
+    trainer_kwargs = dict(
+        max_epochs=1, accumulate_grad_batches={0: 2}, callbacks=cb, limit_train_batches=1, limit_val_batches=0
+    )
+    trainer = Trainer(**trainer_kwargs)
+    trainer.fit(model)
+
+    trainer_kwargs['max_epochs'] = 2
+    trainer_kwargs['resume_from_checkpoint'] = cb.last_model_path
+    trainer = Trainer(**trainer_kwargs)
+    trainer.fit(model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,18 @@ import sys
 import threading
 from functools import partial, wraps
 from http.server import SimpleHTTPRequestHandler
+from pathlib import Path
 
 import pytest
 import torch.distributed
 import torch.multiprocessing as mp
+
+from tests import _PATH_DATASETS
+
+
+@pytest.fixture(scope="session")
+def datadir():
+    return Path(_PATH_DATASETS)
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/deprecated_api/test_remove_1-6.py
+++ b/tests/deprecated_api/test_remove_1-6.py
@@ -21,6 +21,7 @@ from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.plugins.training_type import DDPPlugin, DDPSpawnPlugin
 from pytorch_lightning.utilities.distributed import rank_zero_deprecation, rank_zero_warn
 from pytorch_lightning.utilities.model_helpers import is_overridden
+from tests.deprecated_api import _soft_unimport_module
 from tests.helpers import BoringDataModule, BoringModel
 
 
@@ -322,3 +323,10 @@ def test_v1_6_0_deprecated_hpc_load(tmpdir):
     checkpoint_path = trainer.checkpoint_connector.get_max_ckpt_path_from_folder(str(tmpdir))
     with pytest.deprecated_call(match=r"`CheckpointConnector.hpc_load\(\)` was deprecated in v1.4"):
         trainer.checkpoint_connector.hpc_load(checkpoint_path)
+
+
+def test_v1_6_0_deprecated_device_dtype_mixin_import():
+
+    _soft_unimport_module('pytorch_lightning.utilities.device_dtype_mixin')
+    with pytest.deprecated_call(match='will be removed in v1.6'):
+        from pytorch_lightning.utilities.device_dtype_mixin import DeviceDtypeModuleMixin  # noqa: F811 F401

--- a/tests/helpers/advanced_models.py
+++ b/tests/helpers/advanced_models.py
@@ -19,8 +19,13 @@ import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
 from pytorch_lightning.core.lightning import LightningModule
-from tests import PATH_DATASETS
+from pytorch_lightning.utilities.imports import _TORCHVISION_AVAILABLE
+from tests import _PATH_DATASETS
 from tests.helpers.datasets import AverageDataset, MNIST, TrialMNIST
+
+if _TORCHVISION_AVAILABLE:
+    from torchvision import models, transforms
+    from torchvision.datasets import CIFAR10
 
 
 class Generator(nn.Module):
@@ -155,7 +160,7 @@ class BasicGAN(LightningModule):
         return [opt_g, opt_d], []
 
     def train_dataloader(self):
-        return DataLoader(TrialMNIST(root=PATH_DATASETS, train=True, download=True), batch_size=16)
+        return DataLoader(TrialMNIST(root=_PATH_DATASETS, train=True, download=True), batch_size=16)
 
 
 class ParityModuleRNN(LightningModule):
@@ -213,7 +218,47 @@ class ParityModuleMNIST(LightningModule):
 
     def train_dataloader(self):
         return DataLoader(MNIST(
-            root=PATH_DATASETS,
+            root=_PATH_DATASETS,
             train=True,
             download=True,
         ), batch_size=128, num_workers=1)
+
+
+class ParityModuleCIFAR(LightningModule):
+
+    def __init__(self, backbone="resnet101", hidden_dim=1024, learning_rate=1e-3, pretrained=True):
+        super().__init__()
+        self.save_hyperparameters()
+
+        self.learning_rate = learning_rate
+        self.num_classes = 10
+        self.backbone = getattr(models, backbone)(pretrained=pretrained)
+
+        self.classifier = torch.nn.Sequential(
+            torch.nn.Linear(1000, hidden_dim), torch.nn.Linear(hidden_dim, self.num_classes)
+        )
+        self.transform = transforms.Compose([
+            transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
+        ])
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        y_hat = self.backbone(x)
+        y_hat = self.classifier(y_hat)
+        loss = F.cross_entropy(y_hat, y)
+        return {'loss': loss}
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=self.learning_rate)
+
+    def train_dataloader(self):
+        return DataLoader(
+            CIFAR10(
+                root=_PATH_DATASETS,
+                train=True,
+                download=True,
+                transform=self.transform,
+            ),
+            batch_size=32,
+            num_workers=1
+        )

--- a/tests/helpers/boring_model.py
+++ b/tests/helpers/boring_model.py
@@ -154,7 +154,7 @@ class BoringModel(LightningModule):
 
 class BoringDataModule(LightningDataModule):
 
-    def __init__(self, data_dir: str = './'):
+    def __init__(self, data_dir: str = "./"):
         super().__init__()
         self.data_dir = data_dir
         self.non_picklable = None

--- a/tests/helpers/test_datasets.py
+++ b/tests/helpers/test_datasets.py
@@ -16,14 +16,14 @@ import pickle
 import cloudpickle
 import pytest
 
-from tests import PATH_DATASETS
+from tests import _PATH_DATASETS
 from tests.helpers.datasets import AverageDataset, MNIST, TrialMNIST
 
 
 @pytest.mark.parametrize(
     'dataset_cls,args', [
-        (MNIST, dict(root=PATH_DATASETS)),
-        (TrialMNIST, dict(root=PATH_DATASETS)),
+        (MNIST, dict(root=_PATH_DATASETS)),
+        (TrialMNIST, dict(root=_PATH_DATASETS)),
         (AverageDataset, {}),
     ]
 )

--- a/tests/models/data/horovod/train_default_model.py
+++ b/tests/models/data/horovod/train_default_model.py
@@ -55,14 +55,22 @@ def run_test_from_config(trainer_options, on_gpu, check_size=True):
 
     class TestModel(BoringModel):
 
+        def on_train_start(self) -> None:
+            expected_device = torch.device("cuda", self.trainer.local_rank) if on_gpu else torch.device("cpu")
+            assert self.device == expected_device
+
         def training_epoch_end(self, outputs) -> None:
             res = self.trainer.training_type_plugin.reduce(torch.tensor(1., device=self.device), reduce_op="sum")
             assert res.sum() == self.trainer.training_type_plugin.world_size
 
     model = TestModel()
     trainer = Trainer(**trainer_options)
+
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
+    trainer.test(model)
+
+    assert model.device == torch.device("cpu")
 
     # Horovod should be initialized following training. If not, this will raise an exception.
     if check_size:


### PR DESCRIPTION
Deprecate the method `LightningModule.summarize` and move it to its own function in `pytorch_lightning/utilities/model_summary.py`. Additionally, move `LayerSummary` and `ModelSummary`, along with all of their supporting functions, from `pytorch_lightning/core/memory.py` into the same `model_summary.py` file.

Fixes #8478
